### PR TITLE
Enable reminders timestamp feature

### DIFF
--- a/src/tests/cases/reminders_cli_lists_active_reminders/expected/reminders.json
+++ b/src/tests/cases/reminders_cli_lists_active_reminders/expected/reminders.json
@@ -1,1 +1,1 @@
-[{"title": "2022.02.15: cause my mind has lost direction", "line": 4}, {"title": "2023.04.01 13:45: timing is urgent", "line": 6}, {"title": "2024.11.05: never forget", "line": 3}]
+[{"title": "cause my mind has lost direction", "line": 4, "timestamp_gmt": "1644904800"}, {"title": "timing is urgent", "line": 6, "timestamp_gmt": "1680356700"}, {"title": "never forget", "line": 3, "timestamp_gmt": "1730786400"}]

--- a/src/tests/future/reminders_cli_lists_active_reminders/expected/main.md
+++ b/src/tests/future/reminders_cli_lists_active_reminders/expected/main.md
@@ -1,7 +1,0 @@
-# this is a topic that contains calendar-bound reminders
-- [ ] plain task
-- [!] 2024.11.05: never forget
-- [!] 2022.02.15: cause my mind has lost direction
-- [!] 2023-01-05: may the force
-- [!] 2023.04.01 13:45: timing is urgent
-- [-] ongoing task

--- a/src/tests/future/reminders_cli_lists_active_reminders/expected/main.sh
+++ b/src/tests/future/reminders_cli_lists_active_reminders/expected/main.sh
@@ -1,2 +1,0 @@
-set -e
-$task_master --reminders ./main.md > reminders.json

--- a/src/tests/future/reminders_cli_lists_active_reminders/expected/reminders.json
+++ b/src/tests/future/reminders_cli_lists_active_reminders/expected/reminders.json
@@ -1,1 +1,0 @@
-[{"title":"cause my mind has lost direction","timestamp":"1644894000","line":4},{"title":"timing is urgent","timestamp":"1680345900","line":6},{"title":"never forget","timestamp":"1680345900","line":3}]

--- a/src/tests/future/reminders_cli_lists_active_reminders/setup/main.md
+++ b/src/tests/future/reminders_cli_lists_active_reminders/setup/main.md
@@ -1,7 +1,0 @@
-# this is a topic that contains calendar-bound reminders
-- [ ] plain task
-- [!] 2024.11.05: never forget
-- [!] 2022.02.15: cause my mind has lost direction
-- [!] 2023-01-05: may the force
-- [!] 2023.04.01 13:45: timing is urgent
-- [-] ongoing task

--- a/src/tests/future/reminders_cli_lists_active_reminders/setup/main.sh
+++ b/src/tests/future/reminders_cli_lists_active_reminders/setup/main.sh
@@ -1,2 +1,0 @@
-set -e
-$task_master --reminders ./main.md > reminders.json


### PR DESCRIPTION
## Summary
- support timestamps in reminders CLI
- update reminders CLI test case and move it out of future tests
- use GMT timestamps in reminders
- fix GMT timestamp calculation

## Testing
- `pytest -q src/test.py`


------
https://chatgpt.com/codex/tasks/task_e_684c25bf43b0832b93119e7912d5d7fb