### PR TITLE
Update reminders logic

### DIFF
--- a/src/tests/cases/reminders_cli_lists_active_reminders/expected/main.md
+++ b/src/tests/cases/reminders_cli_lists_active_reminders/expected/main.md
@@ -5,3 +5,4 @@
 - [!] 2023-01-05: may the force
 - [!] 2023.04.01 13:45: timing is urgent
 - [-] ongoing task
+- [!] 2026.01.01: into the future

--- a/src/tests/cases/reminders_cli_lists_active_reminders/expected/reminders.json
+++ b/src/tests/cases/reminders_cli_lists_active_reminders/expected/reminders.json
@@ -1,1 +1,1 @@
-[{"title": "cause my mind has lost direction", "line": 4, "timestamp_gmt": "1644904800"}, {"title": "timing is urgent", "line": 6, "timestamp_gmt": "1680356700"}, {"title": "never forget", "line": 3, "timestamp_gmt": "1730786400"}]
+[{"title": "cause my mind has lost direction", "line": 4, "timestamp_gmt": "1644883200"}, {"title": "timing is urgent", "line": 6, "timestamp_gmt": "1680356700"}, {"title": "never forget", "line": 3, "timestamp_gmt": "1730764800"}, {"title": "into the future", "line": 8, "timestamp_gmt": "1767225600"}]

--- a/src/tests/cases/reminders_cli_lists_active_reminders/setup/main.md
+++ b/src/tests/cases/reminders_cli_lists_active_reminders/setup/main.md
@@ -5,3 +5,4 @@
 - [!] 2023-01-05: may the force
 - [!] 2023.04.01 13:45: timing is urgent
 - [-] ongoing task
+- [!] 2026.01.01: into the future


### PR DESCRIPTION
## Summary
- remove extra reminders function
- rename reminder extraction to use an `active_only` flag
- update CLI to gather all reminders
- revert reminder timestamp formatting
- add unexpired reminder to CLI test case
- revert midnight timestamp adjustment

## Testing
- `./setup.sh`
- `./src/testrun.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c81acaebc832bb32bae40b7d7c776